### PR TITLE
-order-by can't take a hashref

### DIFF
--- a/t/order-by-hashref-params.t
+++ b/t/order-by-hashref-params.t
@@ -1,0 +1,18 @@
+use strict;
+use warnings;
+use Test::More;
+use SQL::Abstract::More;
+
+my $sqla = SQL::Abstract::More->new;
+
+my ( $sql, @bind ) = $sqla->select(
+	-columns  => [qw( foo ) ],
+	-from     => [ 'bar' ],
+	-where    => { 'bar.foo' => 1 },
+	-order_by => [ '-foo'],
+);
+
+is $sql, 'SELECT foo FROM bar WHERE ( bar.foo = ? ) ORDER BY foo DESC', 'SQL';
+is_deeply \@bind, [ 1 ], 'bind params';
+
+done_testing;


### PR DESCRIPTION
This commit provides a  regression test for failing -order-by => { -desc => 'param' }, it does not however fix the problem

Signed-off-by: Caleb Cushing xenoterracide@gmail.com
