### PR TITLE
honor SQL::Abstract quoting settings

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -237,7 +237,7 @@ sub select {
                  \s*          # ignore insignificant trailing spaces
                  $/x) {
       $aliased_columns{$2} = $1;
-      $col = $self->column_alias($1, $2);
+      $col = \( $self->column_alias($self->_quote($1), $2) );
     }
   }
   $args{-columns} = \@cols;
@@ -570,7 +570,7 @@ sub _parse_table {
 
   # build a table spec
   return {
-    sql            => $self->table_alias($table, $alias),
+    sql            => $self->table_alias($self->_quote($table), $alias),
     bind           => [],
     name           => ($alias || $table),
     aliased_tables => {$alias ? ($alias => $table) : ()},
@@ -608,6 +608,10 @@ sub _parse_join_spec {
   s/''/'/g for @constants;  # replace pairs of quotes by single quotes
 
   # accumulate conditions as pairs ($left => \"$op $right")
+
+  my $S = $self->{name_sep}; # TODO: honor $self->{escape_char} as well
+  $S = '.' unless defined $S;
+
   my @conditions;
   foreach my $cond (split /,/, $cond_list) {
     # parse the condition (left and right operands + comparison operator)
@@ -615,8 +619,8 @@ sub _parse_join_spec {
       or croak "can't parse join condition: $cond";
 
     # if operands are not qualified by table/alias name, add sprintf hooks
-    $left  = "%1\$s.$left"  unless $left  =~ /\./;
-    $right = "%2\$s.$right" unless $right =~ /\./ or $right eq $placeholder;
+    $left  = "%1\$s$S$left"  unless $left  =~ /\Q$S\E/;
+    $right = "%2\$s$S$right" unless $right =~ /\Q$S\E/ or $right eq $placeholder;
 
     # add this pair into the list; right operand is either a bind value
     # or an identifier within the right table
@@ -641,6 +645,7 @@ sub _single_join {
 
   # compute the "ON" clause (assuming it contains '%1$s', '%2$s' for
   # left/right tables)
+  # TODO: use $self->_recurse_where() to get conditions without WHERE (...) wrapper
   my ($sql, @bind) = $self->where($join_spec->{condition});
   $sql =~ s/^\s*WHERE\s+//;
   $sql = sprintf $sql, $left->{name}, $right->{name};
@@ -877,7 +882,7 @@ sub _make_AS_through_sprintf {
   my $syntax = $self->{$attribute};
   $self->{$attribute} = sub {
     my ($self, $name, $alias) = @_;
-    return $alias ? sprintf($syntax, $name, $alias) : $name;
+    return $alias ? sprintf($syntax, $name, $self->_quote($alias)) : $name;
   };
 }
 

--- a/t/04-quote.t
+++ b/t/04-quote.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+no warnings qw/qw/;
+use Test::More;
+
+use SQL::Abstract::More;
+use SQL::Abstract::Test import => ['is_same_sql_bind'];
+
+
+plan tests => 1;
+
+my $sqla  = SQL::Abstract::More->new(
+    quote_char   => '`',
+    #quote_char   => ['[',']'],
+    name_sep     => '!',
+    #escape_char => '`',
+);
+my ($sql, @bind);
+
+
+($sql, @bind) = $sqla->select(
+    -columns => [ 'A!col_A', 'B!col_B|b' ],
+    -from    => [-join => qw/A fk=pk B /],
+    -where    => {
+       'A!foo' => 'a',
+       'b!foo' => 'b',
+    },
+);
+is_same_sql_bind(
+  $sql, \@bind,
+  "SELECT `A`!`col_A`, `B`!`col_B` AS `b` FROM `A` INNER JOIN `B` ON ( `A`!`fk` = `B`!`pk` ) WHERE ( ( `A`!`foo` = ? AND `b`!`foo` = ? ) )",
+  ['a', 'b'],
+);


### PR DESCRIPTION
Hi Laurent,

please review my fixes to apply SQLA's quote_char and name_sep settings.
SQL::Abstract itself quotes table names and columns, but since SQLA::More generates  "FROM ..." part it responsible for quoting. This includes: table names, alias names,  column names in ON conditions. It's still possible that something it's not handled by this fix.

Also consider using $sqla->_recurse_where() to get conditions without WHERE (...) wrapper. This change requires to update so many tests (including DBIx::DataModel's) because "()" will be eliminated as well. So I left this decision for your consideration.
