### PR TITLE
Disabled redundant warnings on sprintf

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -655,7 +655,10 @@ sub _single_join {
   # left/right tables)
   my ($sql, @bind) = $self->where($join_spec->{condition});
   $sql =~ s/^\s*WHERE\s+//;
-  $sql = sprintf $sql, $left->{name}, $right->{name};
+  {
+    no warnings 'redundant';
+    $sql = sprintf $sql, $left->{name}, $right->{name};
+  }
 
   # assemble all elements
   my $syntax = $self->{join_syntax}{$join_spec->{operator}};


### PR DESCRIPTION
Avec les nouvelles versions de Perl (5.22.1) il y a un warning si l'on appel sprintf avec un nombre de paramètre qui ne correspond pas aux tags dans le champ FORMAT. C'est simplement reproductible avec les tests déjà disponible (01-sql_abstract_more.t).

Voici le message :
t/01-sql_abstract_more.t .... 1/59 Redundant argument in sprintf at /home/yves/workspace/SQL-Abstract-More/blib/lib/SQL/Abstract/More.pm line 665.

Il semble que cela est assez largement utilisé dans SQL::Abstract::More et pour faire simple je propose simplement de désactiver ce warning, puisque c'est clairement le fonctionnement voulu.