### PR TITLE
Fix license string

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ use inc::Module::Install;
 name     'SQL-Abstract-More';
 all_from 'lib/SQL/Abstract/More.pm';
 author   q{Laurent Dami <dami@cpan.org>};
-license  'artistic2';
+license  'artistic_2';
 
 perl_version 5.008;
 


### PR DESCRIPTION
The value for the "license" field has been changed to "artistic_2" to match the [CPAN Meta Spec](https://metacpan.org/pod/CPAN::Meta::Spec#license).

I was assigned this dist for the [CPAN PR Challenge](http://cpan-prc.org/) this month but unfortunately have had almost no time to work on it. I see that you've recently attended to some of the outstanding bugs. If there's anything else you think needs looking at in the short term feel free to let me know.