### PR TITLE
Proposed fix for #13 that keeps scalar -columns scalar

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -242,20 +242,22 @@ sub select {
   # into a separate list @post_select, later re-injected into the SQL
   my @cols = ref $args{-columns} ? @{$args{-columns}} : $args{-columns};
   my @post_select;
-  push @post_select, shift @cols while @cols && $cols[0] =~ s/^-//;
-  foreach my $col (@cols) {
-    # extract alias, if any
-    if ($col =~ /^\s*         # ignore insignificant leading spaces
-                 (.*[^|\s])   # any non-empty string, not ending with ' ' or '|'
-                 \|           # followed by a literal '|'
-                 (\w+)        # followed by a word (the alias))
-                 \s*          # ignore insignificant trailing spaces
-                 $/x) {
-      $aliased_columns{$2} = $1;
-      $col = $self->column_alias($1, $2);
+  if (ref $args{-columns}) {
+    push @post_select, shift @cols while @cols && $cols[0] =~ s/^-//;
+    foreach my $col (@cols) {
+      # extract alias, if any
+      if ($col =~ /^\s*         # ignore insignificant leading spaces
+                   (.*[^|\s])   # any non-empty string, not ending with ' ' or '|'
+                   \|           # followed by a literal '|'
+                   (\w+)        # followed by a word (the alias))
+                   \s*          # ignore insignificant trailing spaces
+                   $/x) {
+        $aliased_columns{$2} = $1;
+        $col = $self->column_alias($1, $2);
+      }
     }
+    $args{-columns} = \@cols;
   }
-  $args{-columns} = \@cols;
 
   # reorganize pagination
   if ($args{-page_index} || $args{-page_size}) {

--- a/t/01-sql_abstract_more.t
+++ b/t/01-sql_abstract_more.t
@@ -8,7 +8,7 @@ use Test::More;
 use SQL::Abstract::Test import => [qw/is_same_sql_bind/];
 
 use constant N_DBI_MOCK_TESTS =>  2;
-use constant N_BASIC_TESTS    => 68;
+use constant N_BASIC_TESTS    => 69;
 plan tests => (N_BASIC_TESTS + N_DBI_MOCK_TESTS);
 
 diag( "Testing SQL::Abstract::More $SQL::Abstract::More::VERSION, Perl $], $^X" );
@@ -841,4 +841,14 @@ is_same_sql_bind(
     . 'LEFT OUTER JOIN "t3" AS "right" ON ("link"."t3_id" = "right"."id")',
 
   [],
+);
+
+# raw columns
+($sql, @bind) = $sqla->select(
+  -columns  => 'Foo.foo, Foo.bar',
+  -from     => 'Foo'
+);
+is_same_sql_bind(
+  $sql, \@bind,
+  'SELECT Foo.foo, Foo.bar FROM "Foo"', [],
 );

--- a/t/rt_099455.t
+++ b/t/rt_099455.t
@@ -14,7 +14,7 @@ my $sqla = SQL::Abstract::More->new();
 
 my ($sql,@bind) = $sqla->select(
   -from    => 'foo',
-  -columns => q[ concat_ws( ' ', t2.first_name,t2.last_name )|assigned_by_long ],
+  -columns => [ q[ concat_ws( ' ', t2.first_name,t2.last_name )|assigned_by_long ] ],
 );
 
 is_same_sql_bind (


### PR DESCRIPTION
If the `-columns` argument to select is scalar, pass it directly to `SQL::Abstract` without enclosing it in an array ref.  I've added a test for the issue.

I've also changed the test for [RT#99455 ](https://rt.cpan.org/Public/Bug/Display.html?id=99455), because it used a scalar to test aliasing.  Having looked at the original issue on rt.cpan.org, the original code used an array ref, so I think the updated `rt_099455.t` is still a good test.