### PR TITLE
Fix comptibility

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -472,6 +472,10 @@ sub _parse_columns {
 sub _parse_from {
   my ($self, $from) = @_;
 
+  if (ref $from eq 'ARRAY' and @$from == 1) {
+    $from = $from->[0];
+  }
+
   my @from_bind;
   my $aliased_tables = {};
 

--- a/t/01-sql_abstract_more.t
+++ b/t/01-sql_abstract_more.t
@@ -38,6 +38,18 @@ is_same_sql_bind(
   "SELECT bar FROM Foo WHERE bar > ? ORDER BY bar", [123],
 );
 
+# idem, new API: pass one table as array
+($sql, @bind) = $sqla->select(
+  -columns  => [qw/bar/],
+  -from     => ['Foo'],
+  -where    => {bar => {">" => 123}},
+  -order_by => ['bar']
+);
+is_same_sql_bind(
+  $sql, \@bind,
+  "SELECT bar FROM Foo WHERE bar > ? ORDER BY bar", [123],
+);
+
 # -from with alias
 ($sql, @bind) = $sqla->select(
   -columns  => [qw/bar/],


### PR DESCRIPTION
Prior to 1.41, the `-from` option allowed references to arrays containing only one table.
This fix allows again the notation `-from => ['table']`.

This behavior is undocumented, but my module (https://metacpan.org/pod/Teng::Plugin::SearchBySQLAbstractMore) relies on it.
If you do not want this change, do not bother and close this pull request. I will modify my module.