### PR TITLE
Support table name aliases in update and delete statements

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -883,7 +883,10 @@ sub update {
 
     # compute join info if the datasource is a join
     $join_info = $self->_compute_join_info($args{-table});
-    $args{-table} = \($join_info->{sql}) if $join_info;
+    $args{-table} =
+      defined $join_info
+      ? \($join_info->{sql})
+      : \($self->_parse_table( $args{-table})->{sql});
 
     @old_API_args = @args{qw/-table -set -where/};
 
@@ -897,6 +900,7 @@ sub update {
   }
 
   # call parent method and merge with bind values from $join_info
+
   my ($sql, @bind) = $self->_parent_update(@old_API_args);
 
   unshift @bind, @{$join_info->{bind}} if $join_info;
@@ -937,6 +941,8 @@ sub delete {
   else {
     @old_API_args = @_;
   }
+
+  $old_API_args[0] = \($self->_parse_table( $old_API_args[0] )->{sql});
 
   # call parent method
   my ($sql, @bind) = $self->next::method(@old_API_args);

--- a/t/01-sql_abstract_more.t
+++ b/t/01-sql_abstract_more.t
@@ -945,6 +945,17 @@ is_same_sql_bind(
   [2, 1, 3],
 );
 
+# support for table aliases
+($sql, @bind) = $sqla->update(
+  -table => 'Foo|a',
+  -set => {foo => 1, bar => 2},
+  -where => {buz => 3},
+);
+is_same_sql_bind(
+  $sql, \@bind,
+  'UPDATE Foo SET bar = ?, foo = ? WHERE buz = ?',
+  [2, 1, 3],
+);
 
 # MySQL supports -limit and -order_by in updates !
 # see http://dev.mysql.com/doc/refman/5.6/en/update.html
@@ -1051,6 +1062,17 @@ is_same_sql_bind(
 is_same_sql_bind(
   $sql, \@bind,
   'DELETE FROM Foo WHERE buz = ?',
+  [3],
+);
+
+# support for table aliases
+($sql, @bind) = $sqla->delete(
+  -from => 'Foo|a',
+  -where => {buz => 3},
+);
+is_same_sql_bind(
+  $sql, \@bind,
+  'DELETE FROM Foo AS a WHERE buz = ?',
   [3],
 );
 


### PR DESCRIPTION
A number of SQL databases (e.g. PostgreSQL, SQLite) support table aliases in `update` and `delete` statements.  This commit adds support for this.

This will allow upstream users of `SQL::Abstract::More` (e.g. `DBIx::Lite)` to correctly support table aliases in these situations. Currently `DBIx::Lite` passes [->table_alias($table_name, $table_alias);](https://github.com/alranel/DBIx-Lite/blob/e5bddafc1ca80843e19e3e5689ec67b091775489/lib/DBIx/Lite/ResultSet.pm#L652) as the table name to the `delete` and `update` methods, which works, fortuitously,  unless `quote_char` is set in which the the entire "table name" which consists of e.g, `"foo" AS "alias"` is turned into `""foo" AS "alias""` which is rejected as incorrect SQL by the DB server.