### PR TITLE
better handle quoted columns and tables

### DIFF
--- a/lib/SQL/Abstract/More.pm
+++ b/lib/SQL/Abstract/More.pm
@@ -19,7 +19,7 @@ use namespace::clean;
 # declare error-reporting functions from SQL::Abstract
 sub puke(@); sub belch(@);  # these will be defined later in import()
 
-our $VERSION = '1.44';
+our $VERSION = '1.44_01';
 our @ISA;
 
 sub import {
@@ -318,7 +318,7 @@ sub with {
     my ($sql, @bind) = $self->select(%{$args{-as_select}});
     $clone->{WITH}{sql} .= ", " if $clone->{WITH}{sql};
     $clone->{WITH}{sql} .= $args{-table};
-    $clone->{WITH}{sql} .= "(" . join(", ", @cols) . ")"   if @cols;
+    $clone->{WITH}{sql} .= "(" . join(", ", map { $self->_quote($_) } @cols) . ")"   if @cols;
     $clone->{WITH}{sql} .= " AS ($sql) ";
     $clone->{WITH}{sql} .= $args{-final_clause} . " "      if $args{-final_clause};
     push @{$clone->{WITH}{bind}}, @bind;
@@ -361,11 +361,14 @@ sub select {
 
   # parse columns and datasource
   my ($cols, $post_select, $cols_bind, $aliased_columns) = $self->_parse_columns($args{-columns});
-  my ($from,               $from_bind, $aliased_tables)  = $self->_parse_from($args{-from});
+  my ($from,               $from_bind, $aliased_tables, $is_literal)  = $self->_parse_from($args{-from});
   $add_sql_bind->("", @$cols_bind, @$from_bind);
 
+  # our columns are already appropriately quoted, so prevent SQLA from
+  # double quoting
+  $cols = CORE::join( ', ', map { ref $_ ? $$_ : $_ } @$cols );
   # generate main ($sql, @bind) through the old positional API
-  $add_sql_bind->($self->next::method($from, $cols, $args{-where}));
+  $add_sql_bind->($self->next::method($is_literal ? \$from : $from, $cols, $args{-where}));
 
   # add @post_select clauses if needed (for ex. -distinct)
   my $all_post_select = join " ", @$post_select;
@@ -374,7 +377,8 @@ sub select {
   # add set operators (UNION, INTERSECT, etc) if needed
   foreach my $set_op (@set_operators) {
     if (my $val_set_op = $args{-$set_op}) {
-      my ($sql_set_op, @bind_set_op) = $self->_parse_set_operator($set_op => $val_set_op, $cols, $from);
+      # pass original columns spec instead of $cols, or they may be multiply quoted.
+      my ($sql_set_op, @bind_set_op) = $self->_parse_set_operator($set_op => $val_set_op, $args{-columns}, $from);
       $add_sql_bind->($sql_set_op, @bind_set_op);
     } 
   }
@@ -432,6 +436,15 @@ sub select {
 }
 
 
+# return true if column should be quoted.
+sub _quotable_identifier {
+    my ( $name ) = @_;
+
+    # quote $name unless it is an SQL expression (then the user should quote it)
+    $name !~ /[()]/;
+}
+
+
 sub _parse_columns {
   my ($self, $columns) = @_;
 
@@ -448,11 +461,20 @@ sub _parse_columns {
   my %aliased_columns;
   foreach my $col (@cols) {
 
+    # columns which are scalar refs are literal SQL and don't require
+    # processing.
+    next if does( $col, 'SCALAR' );
+
+    my $quote_name = 1;
+
     # deal with subquery of shape \ [$sql, @bind]
     if (_is_subquery($col)) {
       my ($sql, @col_bind) = @$$col;
       $sql =~ s{^(select.*)}{($1)}is; # if subquery is a plain SELECT, put it in parenthesis
       $col = $sql;
+
+      # $col is an expression, so don't quote it.
+      $quote_name = 0;
       push @cols_bind, @col_bind;
     }
 
@@ -464,7 +486,12 @@ sub _parse_columns {
                  \s*          # ignore insignificant trailing spaces
                  $/x) {
       $aliased_columns{$2} = $1;
-      $col = $self->column_alias($1, $2);
+      $col = $self->column_alias($1, $2, $quote_name);
+    }
+
+    # bare column; quote if required
+    else {
+        $col = $self->_quote($col) if $quote_name && _quotable_identifier( $col );
     }
   }
 
@@ -477,6 +504,8 @@ sub _parse_from {
 
   my @from_bind;
   my $aliased_tables = {};
+  my $is_literal = 0;
+  my $quote_aliased_name = 1;
 
   my $join_info = $self->_compute_join_info($from);
   if ($join_info) {
@@ -484,6 +513,25 @@ sub _parse_from {
     @from_bind      = @{$join_info->{bind}};
     $aliased_tables = $join_info->{aliased_tables};
   }
+
+  # compatibility with old SQL::Abstract syntax for $source
+  elsif (does($from, 'ARRAY')) {
+      my @from;
+      my @aliased_tables;
+
+      # array elements may need to be quoted/aliased
+      for my $table ( @$from ) {
+        my $table_spec  = $self->_parse_table($table);
+        my $sql = $table_spec->{sql};
+        push @from, $table_spec->{is_literal} ? $sql : $self->_quote($sql);
+        push @aliased_tables, %{ $table_spec->{aliased_tables} };
+      }
+      $from = join ", ", @from;
+      $aliased_tables = { @aliased_tables };
+
+      # this is now the final SQL, should not be further quoted.
+      $is_literal = 1;
+    }
   else {
 
     # if -from is a subquery, separate the $sql and @bind parts
@@ -491,23 +539,23 @@ sub _parse_from {
       my ($sql, @bind) = @$$from;
       $sql =~ s{^(\s*select.*)}{($1)}is; # if subquery is a plain SELECT, put it in parenthesis
       $from = $sql;
+
+      # $sql is an expression, so _parse_table (called below) shouldn't quote it.
+      $quote_aliased_name = 0;
       push @from_bind, @bind;
     }
 
-    # conditions below : compatibility with old SQL::Abstract syntax for $source
-    elsif (does($from, 'ARRAY')) {
-      $from = join ", ", @$from;
-    }
     elsif (does($from, 'SCALAR')) {
       $from = $$from;
     }
 
-    my $table_spec  = $self->_parse_table($from);
+    my $table_spec  = $self->_parse_table($from, quote_aliased_name => $quote_aliased_name);
     $from           = $table_spec->{sql};
+    $is_literal     = $table_spec->{is_literal};
     $aliased_tables = $table_spec->{aliased_tables};
   }
 
-  return ($from, \@from_bind, $aliased_tables);
+  return ($from, \@from_bind, $aliased_tables, $is_literal);
 }
 
 
@@ -679,7 +727,10 @@ sub insert {
       my ($sql, @bind) = $self->select(%{$args{-select}});
       $old_API_args[1] = \ [$sql, @bind];
       if (my $cols = $args{-columns}) {
-        $old_API_args[0] .= "(" . CORE::join(", ", @$cols) . ")";
+          $old_API_args[0] =
+            \( $self->_quote($old_API_args[0]) .
+               "(" . CORE::join(", ", map { $self->_quote($_) } @$cols) . ")"
+           );
       }
       $fix_RT134127 = 1 if ($SQL::Abstract::VERSION || 0) >= 2.0;
     }
@@ -884,7 +935,7 @@ sub update {
     # compute SQL for datasource to be updated
     $join_info    = $self->_compute_join_info($args{-table});
     $args{-table} = defined $join_info  ? \($join_info->{sql})
-                                        : $self->_parse_table($args{-table})->{sql};
+                                        : \($self->_parse_table($args{-table}, quote_name => 1)->{sql});
 
     @old_API_args = @args{qw/-table -set -where/};
 
@@ -932,7 +983,9 @@ sub delete {
   my %args;
   if (&_called_with_named_args) {
     %args         = validate(@_, \%params_for_delete);
-    $args{-from}  = $self->_parse_table($args{-from})->{sql};
+    # this will always return literal (possibly quoted) SQL, so don't
+    # further quote it.
+    $args{-from}  = \($self->_parse_table($args{-from}, quote_name => 1)->{sql});
     @old_API_args = @args{qw/-from -where/};
   }
   else {
@@ -1055,7 +1108,7 @@ sub join {
 
   # shift first single item (a table) before reducing pairs (op, table)
   my $combined = shift;
-  $combined    = $self->_parse_table($combined)      unless ref $combined;
+  $combined    = $self->_parse_table($combined, quote_name => 1)      unless ref $combined;
 
   # reduce pairs (op, table)
   while (@_) {
@@ -1064,7 +1117,7 @@ sub join {
     my $table_spec = shift or puke "improper number of operands";
 
     $join_spec  = $self->_parse_join_spec($join_spec) unless ref $join_spec;
-    $table_spec = $self->_parse_table($table_spec)    unless ref $table_spec;
+    $table_spec = $self->_parse_table($table_spec, quote_name => 1)    unless ref $table_spec;
     $combined   = $self->_single_join($combined, $join_spec, $table_spec);
   }
 
@@ -1167,18 +1220,104 @@ sub _compute_join_info {
   }
 }
 
-sub _parse_table {
-  my ($self, $table) = @_;
+=for documentation
 
+=head3 _parse_table
+
+  \%spec = $sqla->_parse_table( $table_spec, %args );
+
+Parse a table specification C<$table_spec>, as a string, which
+consists of a
+
+ * a table name or an expression (such as a select);
+
+ * an optional alias
+
+The two elements are separated by the C<|> character.
+
+C<%args> may contain the following entries:
+
+=over
+
+=item quote_aliased_name => boolean
+
+If the specification contains an alias, quote the table name in addition to the alias (the alias
+will always be quoted).  When this is set, the caller must ensure that the table name is not
+an expression, otherwise incorrect SQL will be produced.
+
+=item quote_name => boolean
+
+Always quote the table name, whether or not it is aliased.  When this
+is set, the caller must ensure that the table name is not an
+expression, otherwise incorrect SQL will be produced.
+
+=back
+
+Returns a hash with the entries:
+
+=over
+
+=back
+
+The "sql"' element may be fully or partially quoted; this decision is
+up to the calling routine, which must understand the context in which the
+"sql" element is used.
+
+For example, if the table specification elements are <expression>|<alias>,
+then the "aliased name" (<expresson>) should not be quoted, and the
+quote_aliased_name option should be false.
+
+If the resultant sql is to be directly embedded into a string, then
+
+=over
+
+=item sql => string
+
+SQL for the table name or expression which may be interpolated.  Note
+that if the passed table specification does not include an alias and
+the L</quote_name> is not set the resultant SQL will not contain a quoted
+table name/expression.  The caller must decide if this is appropriate for the
+context in which the parsed table specification is used.
+
+=item   bind => array
+
+SQL bind values.
+
+=item  name  => string
+
+The table name or expression, or if an alias was provided, the alias.
+This will not be quoted.
+
+=item aliased_tables => \%hash
+
+A hash keyed off of the unquoted alias, with the unquoted table name/expression as the value.
+
+=item is_literal => boolean
+
+True if the SQL hould be interpolated as-is, without further quotation.
+
+=back
+
+=cut
+
+sub _parse_table {
+  my ($self, $table) = ( shift, shift );
+
+  my %args = (
+      quote_aliased_name => 1,
+      quote_name => 0,
+      @_
+  );
   # extract alias, if any (recognized as "table|alias")
   ($table, my $alias) = split /\|/, $table, 2;
 
   # build a table spec
   return {
-    sql            => $self->table_alias($table, $alias),
+    sql            => $self->table_alias($table, $alias, %args ),
     bind           => [],
     name           => ($alias || $table),
     aliased_tables => {$alias ? ($alias => $table) : ()},
+    is_literal     => $args{quote_name} && _quotable_identifier($table) || defined $alias,
    };
 }
 
@@ -1263,13 +1402,13 @@ sub _single_join {
         or puke "join specification has both {condition} and {using} fields";
 
       $syntax =~ s/\bON\s+%s/USING (%s)/;
-      $sql = CORE::join ",", @{$join_spec->{using}};
+      $sql = CORE::join ",", map { $self->_parse_table( $_, quote_name => 1 )->{sql} } @{$join_spec->{using}};
     }
     elsif ($join_spec->{condition}) {
       not $join_spec->{using}
         or puke "join specification has both {condition} and {using} fields";
 
-      # compute the "ON" clause
+      # compute the "ON" clause; this handles quoting of table names
       ($sql, @bind) = $self->where($join_spec->{condition});
       $sql =~ s/^\s*WHERE\s+//;
 
@@ -1479,11 +1618,14 @@ sub _make_sub_column_alias {
   my ($self) = @_;
   my $syntax = $self->{column_alias};
   $self->{column_alias} = sub {
-    my ($self, $name, $alias) = @_;
-    return $name if !$alias;
+    my ($self, $name, $alias, $quote_name) = @_;
+
+    $quote_name = 1 if ! defined $quote_name;
 
     # quote $name unless it is an SQL expression (then the user should quote it)
-    $name = $self->_quote($name) unless $name =~ /[()]/;
+    $name = $self->_quote($name) if $quote_name && _quotable_identifier( $name );
+
+    return $name if !$alias;
 
     # assemble syntax
     my $sql = sprintf $syntax, $name, $self->_quote($alias);
@@ -1498,11 +1640,23 @@ sub _make_sub_table_alias {
   my ($self) = @_;
   my $syntax = $self->{table_alias};
   $self->{table_alias} = sub {
-    my ($self, $name, $alias) = @_;
-    return $name if !$alias;
+      my ($self, $name, $alias ) = (shift, shift, shift );
+
+      my %args = (
+          quote_aliased_name => 1,
+          quote_name => 0,
+          @_,
+      );
+    $args{quote_aliased_name} &&= _quotable_identifier( $name );
+    $args{quote_name}         &&= _quotable_identifier( $name );
+
+    # quote $name unless it is an SQL expression (then the user should quote it)
+    return $args{quote_name} ? $self->_quote($name) : $name if !$alias;
 
     # assemble syntax
-    my $sql = sprintf $syntax, $self->_quote($name), $self->_quote($alias);
+    my $sql = sprintf $syntax,
+      ( $args{quote_aliased_name}  ? $self->_quote($name) : $name ),
+      $self->_quote($alias);
 
     return $sql;
   };

--- a/t/08-sql_abstract_more_quoted.t
+++ b/t/08-sql_abstract_more_quoted.t
@@ -14,7 +14,10 @@ diag( "Testing SQL::Abstract::More $SQL::Abstract::More::VERSION, "
 use constant N_DBI_MOCK_TESTS =>  2;
 
 
-my $sqla = SQL::Abstract::More->new;
+sub sqla { SQL::Abstract::More->new (
+    quote_char => q{"}, name_sep => q{.}, @_)
+}
+my $sqla = sqla();
 my ($sql, @bind, $join);
 
 
@@ -23,10 +26,10 @@ my ($sql, @bind, $join);
 #----------------------------------------------------------------------
 
 # old API transmitted to parent
-($sql, @bind) = $sqla->select('Foo', 'bar', {bar => {'>' => 123}}, ['bar']);
+($sql, @bind) = $sqla->select('Foo', ['bar'], {bar => {'>' => 123}}, ['bar']);
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo WHERE bar > ? ORDER BY bar', [123],
+  'SELECT "bar" FROM "Foo" WHERE ( "bar" > ? ) ORDER BY "bar"', [123],
   'old API (positional parameters)',
 );
 
@@ -39,7 +42,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo WHERE bar > ? ORDER BY bar', [123],
+  'SELECT "bar" FROM "Foo" WHERE ( "bar" > ? ) ORDER BY "bar"', [123],
   'new API : named parameters',
 );
 
@@ -52,7 +55,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo WHERE bar > ? ORDER BY bar', [123],
+  'SELECT "bar" FROM "Foo" WHERE "bar" > ? ORDER BY "bar"', [123],
   '-from => arrayref (1 table)',
 );
 
@@ -65,7 +68,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo, Bar, Buz WHERE bar > ?', [123],
+  'SELECT "bar" FROM "Foo", "Bar", "Buz" WHERE ( "bar" > ? )', [123],
   '-from => arrayref (several tables)',
 );
 
@@ -77,7 +80,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo WHERE bar > ?', [123],
+  'SELECT "bar" FROM "Foo" WHERE "bar" > ?', [123],
   '-from => scalarref',
 );
 
@@ -90,7 +93,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT bar FROM Foo AS f WHERE f.bar = ?', [123],
+  'SELECT "bar" FROM "Foo" AS "f" WHERE ( "f"."bar" = ? )', [123],
   '-from with alias'
 );
 
@@ -103,7 +106,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT DISTINCT foo, bar FROM Foo', [],
+  'SELECT DISTINCT "foo", "bar" FROM "Foo"', [],
 );
 
 # other minus signs
@@ -113,7 +116,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT DISTINCT STRAIGHT_JOIN foo, bar FROM Foo', [],
+  'SELECT DISTINCT STRAIGHT_JOIN "foo", "bar" FROM "Foo"', [],
 );
 
 ($sql, @bind) = $sqla->select(
@@ -122,7 +125,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT SQL_SMALL_RESULT foo, bar FROM Foo', [],
+  'SELECT SQL_SMALL_RESULT "foo", "bar" FROM "Foo"', [],
 );
 
 ($sql, @bind) = $sqla->select(
@@ -131,7 +134,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT /*+ FIRST_ROWS (100) */ foo, bar FROM Foo', [],
+  'SELECT /*+ FIRST_ROWS (100) */ "foo", "bar" FROM "Foo"', [],
 );
 
 
@@ -143,14 +146,14 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT col1, (SELECT max(bar) FROM Bar WHERE bar < ?) AS col2, col3 FROM Foo WHERE foo = ?', [123, 456],
+  'SELECT "col1", (SELECT max(bar) FROM Bar WHERE bar < ?) AS "col2", "col3" FROM "Foo" WHERE ( "foo" = ? )', [123, 456],
   'subquery in select list',
 );
 
 
 # subquery as column, example from the doc
 my ($subq_sql, @subq_bind) = $sqla->select(
-                              -columns => 'COUNT(*)',
+                              -columns => 'COUNT(*)|count',
                               -from    => 'Foo',
                               -where   => {bar_id => {-ident => 'Bar.bar_id'},
                                            height => {-between => [100, 200]}},
@@ -163,10 +166,10 @@ my $subquery = ["($subq_sql)|col3", @subq_bind];
                       );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT col1, col2,
-         (SELECT COUNT(*) FROM Foo WHERE bar_id=Bar.bar_id and height BETWEEN ? AND ?) AS col3,
-         col4
-    FROM Bar WHERE color = ?', [100, 200, 'green'],
+  'SELECT "col1", "col2",
+         (SELECT COUNT(*) AS "count" FROM "Foo" WHERE ( ( "bar_id" ="Bar"."bar_id") and ( "height" BETWEEN ? AND ?) ) ) AS "col3",
+         "col4"
+    FROM "Bar" WHERE ("color" = ?)', [100, 200, 'green'],
   'subquery, example from the doc');
 
 
@@ -185,10 +188,10 @@ $subquery = ["($subq_sql)|subq", @subq_bind];
                       );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT subq.*, count(*) AS nb_a
-   FROM (SELECT a, b, c FROM Foo WHERE foo = ?) AS subq
-   WHERE b = ?
-   GROUP BY a',  [123, 456],
+  'SELECT "subq".*, count(*) AS "nb_a"
+   FROM (SELECT "a", "b", "c" FROM "Foo" WHERE ( "foo" = ? )) AS "subq"
+   WHERE ( "b" = ? )
+   GROUP BY "a"',  [123, 456],
    'subquery in -from');
 
 
@@ -211,9 +214,9 @@ is_same_sql_bind(
     );
 is_same_sql_bind(
   $sql, \@bind,
-  ' SELECT x, (SELECT MAX(amount) FROM Expenses WHERE ( date > ? AND exp_id = x)) AS max_amount
-    FROM (SELECT f AS x FROM Foo UNION SELECT b AS x FROM Bar WHERE barbar = ?) AS Foo_union_Bar
-    ORDER BY x', ['01.01.2024', 123],
+  'SELECT "x", (SELECT MAX(amount) FROM "Expenses" WHERE ( ( "date" > ? AND "exp_id" = "x" ) )) AS "max_amount"
+    FROM (SELECT "f" AS "x" FROM "Foo" UNION SELECT "b" AS "x" FROM "Bar" WHERE ( "barbar" = ? )) AS "Foo_union_Bar"
+    ORDER BY "x"', ['01.01.2024', 123],
   'subqueries in column list and in source');
 
 
@@ -227,7 +230,7 @@ my $subq = [ $sqla->select(-columns => 'x',
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo WHERE (x IN (SELECT x FROM Bar WHERE ( y < ? )))',
+  'SELECT * FROM "Foo" WHERE ("x" IN (SELECT "x" FROM "Bar" WHERE ( "y" < ? )))',
   [100],
   'select -in => subquery',
  );
@@ -239,7 +242,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo INNER JOIN Bar ON Foo.fk=Bar.pk', [],
+  'SELECT * FROM "Foo" INNER JOIN "Bar" ON ( "Foo"."fk" = "Bar"."pk" )', [],
   'select from join',
 );
 
@@ -249,28 +252,29 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo INNER JOIN Bar ON Foo.fk=Bar.pk and Foo.other = ?', ['abc'],
+  'SELECT * FROM "Foo" INNER JOIN "Bar" ON ( ( "Foo"."fk"="Bar"."pk" and "Foo"."other" = ? ) )', ['abc'],
   'select from join with bind value',
 );
+
 
 # join with two literal table expressings and using
 ($sql, @bind) = $sqla->select(
        -from => [ -join => 
-                             'SELECT id1 AS id FROM table1 WHERE (id1 > 2)|a',
+                             'SELECT "id1" AS "id" FROM "table1" WHERE ("id1" > 2)|a',
                             {operator => '<=>',
                              using => [ 'id' ]},
-                             'SELECT id2 AS id FROM table2 WHERE (id2 > 2 )|b',
+                             'SELECT "id2" AS "id" FROM "table2" WHERE ("id2" > 2 )|b',
                 ],
        -columns => [ 'a.id1|aid', 'b.id2|bid' ]
 );
 is_same_sql_bind(
   $sql, \@bind,
-  q{ SELECT a.id1 as aid, b.id2 as bid
+  q{ SELECT "a"."id1" as "aid", "b"."id2" as "bid"
     FROM
-      SELECT id1 as id FROM table1 WHERE (id1 > 2) AS a
+      SELECT "id1" as "id" FROM "table1" WHERE ("id1" > 2) AS "a"
     INNER JOIN
-      SELECT id2 as id FROM table2 WHERE (id2 > 2) AS b
-    USING (id )
+      SELECT "id2" as "id" FROM "table2" WHERE ("id2" > 2) AS "b"
+    USING ("id" )
     },
   [],
   'join with two literal table expressings and using'
@@ -289,8 +293,8 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT col1, col2 FROM Foo WHERE col1 = ? '
-  .' INTERSECT SELECT col3, col4 FROM Bar WHERE col3 = ?',
+  'SELECT "col1", "col2" FROM "Foo" WHERE "col1" = ? '
+  .' INTERSECT SELECT "col3", "col4" FROM "Bar" WHERE "col3" = ?',
   [123, 456],
   'from q1 intersect q2',
 );
@@ -307,10 +311,10 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT col1, col2 FROM Foo WHERE col1 = ? '
-  .' UNION ALL SELECT col1, col2 FROM Foo WHERE col2 = ?'
-  .' UNION ALL SELECT col1, col3 FROM Foo WHERE col3 = ?'
-  .' ORDER BY col1, col2',
+  'SELECT "col1", "col2" FROM "Foo" WHERE "col1" = ? '
+  .' UNION ALL SELECT "col1", "col2" FROM "Foo" WHERE "col2" = ?'
+  .' UNION ALL SELECT "col1", "col3" FROM "Foo" WHERE "col3" = ?'
+  .' ORDER BY "col1", "col2"',
   [123, 456, 789],
   'from q1 union_all q2',
 );
@@ -322,7 +326,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo ORDER BY foo DESC, bar ASC, buz', [],
+  'SELECT * FROM "Foo" ORDER BY "foo" DESC, "bar" ASC, "buz"', [],
 );
 
 #-group_by / -having
@@ -334,7 +338,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT foo, SUM(bar) AS sum_bar FROM Foo GROUP BY foo HAVING sum_bar > ?', [10],
+  'SELECT "foo", SUM(bar) AS "sum_bar" FROM "Foo" GROUP BY "foo" HAVING "sum_bar" > ?', [10],
   'group by / having',
 );
 
@@ -347,7 +351,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT SUM(bar) AS sum_bar FROM Foo WHERE ( foo = ? ) HAVING ( sum_bar > ? )', [1,10],
+  'SELECT SUM(bar) AS "sum_bar" FROM "Foo" WHERE ( "foo" = ? ) HAVING ( "sum_bar" > ? )', [1,10],
   'group by / having (2)',
 );
 
@@ -358,7 +362,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo LIMIT ? OFFSET ?', [100, 0],
+  'SELECT * FROM "Foo" LIMIT ? OFFSET ?', [100, 0],
 );
 
 ($sql, @bind) = $sqla->select(
@@ -367,7 +371,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo LIMIT ? OFFSET ?', [0, 0],
+  'SELECT * FROM "Foo" LIMIT ? OFFSET ?', [0, 0],
   'limit 0',
 );
 
@@ -381,7 +385,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo LIMIT ? OFFSET ?', [100, 300],
+  'SELECT * FROM "Foo" LIMIT ? OFFSET ?', [100, 300],
 );
 
 
@@ -393,7 +397,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo LIMIT ? OFFSET ?', [50, 50],
+  'SELECT * FROM "Foo" LIMIT ? OFFSET ?', [50, 50],
 );
 
 
@@ -404,7 +408,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo FOR UPDATE', [],
+  'SELECT * FROM "Foo" FOR UPDATE', [],
 );
 
 # -want_details
@@ -415,7 +419,7 @@ my $details = $sqla->select(
 );
 is_same_sql_bind(
   $details->{sql}, $details->{bind},
-  'SELECT f.col1 AS c1, b.col2 AS c2 FROM Foo AS f INNER JOIN Bar AS b ON f.fk=b.pk', [],
+  'SELECT "f"."col1" AS "c1", "b"."col2" AS "c2" FROM "Foo" AS "f" INNER JOIN "Bar" AS "b" ON ( "f"."fk" = "b"."pk" )', [],
 );
 is_deeply($details->{aliased_tables}, {f => 'Foo', b => 'Bar'}, 
           'aliased tables');
@@ -430,17 +434,17 @@ is_deeply($details->{aliased_columns}, {c1 => 'f.col1', c2 => 'b.col2'},
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT A||B, C||D AS cd, (E||F||G) AS efg, true|false AS bool FROM Foo', [],
+  'SELECT "A||B", "C||D" AS "cd", (E||F||G) AS "efg", "true|false" AS "bool" FROM "Foo"', [],
   'aliased cols with '|''
 );
 
 ($sql, @bind) = $sqla->select(
-  -columns  => [qw/NULL|a1 2|a2 x|a3/],
+  -columns  => [qw/(NULL)|a1 (2)|a2 x|a3/],
   -from     => 'Foo',
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT NULL AS a1, 2 AS a2, x AS a3 FROM Foo', [],
+  'SELECT (NULL) AS "a1", (2) AS "a2", "x" AS "a3" FROM "Foo"', [],
   'aliased cols with '|', single char on left-hand side'
 );
 
@@ -453,7 +457,7 @@ is_same_sql_bind(
  );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo WHERE foo = ?',
+  'SELECT * FROM "Foo" WHERE "foo" = ?',
   [ [{dbd_attrs => {ora_type => 'TEST'}}, 123] ],
   'SQL type with implicit = operator',
 );
@@ -464,7 +468,7 @@ is_same_sql_bind(
  );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo WHERE bar < ?',
+  'SELECT * FROM "Foo" WHERE "bar" < ?',
   [ [{dbd_attrs => {pg_type  => 999}}, 456] ],
   'SQL type with explicit operator',
 );
@@ -476,7 +480,7 @@ is_same_sql_bind(
  );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(x) VALUES(?)',
+  'INSERT INTO "Foo"("x") VALUES(?)',
   [ [{dbd_attrs => {pg_type  => 999}}, 456] ],
   'INSERT with SQL type',
 );
@@ -488,7 +492,7 @@ is_same_sql_bind(
  );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET x = ? WHERE bar = ?',
+  'UPDATE "Foo" SET "x" = ? WHERE "bar" = ?',
   [ [{dbd_attrs => {pg_type  => 999}}, 456], 'buz' ],
   'UPDATE with SQL type',
 );
@@ -502,7 +506,7 @@ is_same_sql_bind(
  );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM Foo WHERE bar IS NULL OR bar < ?',
+  'SELECT * FROM "Foo" WHERE "bar" IS NULL OR "bar" < ?',
   [ 'foo' ],
   'OR arrayref pair which is not a value/type pair',
 );
@@ -516,14 +520,14 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->column_alias(qw/Foo f/);
 is_same_sql_bind(
   $$sql, \@bind,
-  'Foo AS f', [],
+  '"Foo" AS "f"', [],
   'column alias',
 );
 
 ($sql, @bind) = $sqla->column_alias(qw/Foo/);
 is_same_sql_bind(
   $sql, \@bind,
-  'Foo', [],
+  '"Foo"', [],
   'column alias without alias',
 );
 
@@ -531,7 +535,7 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->table_alias(qw/Foo f/);
 is_same_sql_bind(
   $sql, \@bind,
-  'Foo AS f', [],
+  '"Foo" AS "f"', [],
   'table alias',
 );
 
@@ -546,14 +550,14 @@ is_same_sql_bind(
 $join = $sqla->join(qw[Foo|f =>{fk_A=pk_A,fk_B=pk_B} Bar]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Foo AS f LEFT OUTER JOIN Bar ON f.fk_A = Bar.pk_A AND f.fk_B = Bar.pk_B', [],
+  '"Foo" AS "f" LEFT OUTER JOIN "Bar" ON ( ( "f"."fk_A" = "Bar"."pk_A" AND "f"."fk_B" = "Bar"."pk_B" ) )', [],
   'join syntax',
 );
 
 $join = $sqla->join(qw[Foo <=>[A<B,C<D] Bar]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Foo INNER JOIN Bar ON Foo.A < Bar.B OR Foo.C < Bar.D', [],
+  '"Foo" INNER JOIN "Bar" ON ( ( "Foo"."A" < "Bar"."B" OR "Foo"."C" < "Bar"."D" ) )', [],
   'join syntax with OR',
 );
 
@@ -561,7 +565,7 @@ is_same_sql_bind(
 $join = $sqla->join(qw[Foo == Bar]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Foo NATURAL JOIN Bar', [],
+  '"Foo" NATURAL JOIN "Bar"', [],
   'natural join',
 );
 
@@ -572,10 +576,10 @@ $join = $sqla->join(qw[Table1|t1       ab=cd         Table2|t2
                                     =>{t1.mn=op}     Table4]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Table1 AS t1 INNER JOIN      Table2 AS t2 ON t1.ab=t2.cd
-                INNER JOIN      Table3       ON t2.ef>Table3.gh 
-                                            AND t2.ij<Table3.kl
-                LEFT OUTER JOIN Table4       ON t1.mn=Table4.op',
+  '"Table1" AS "t1" INNER JOIN      "Table2" AS "t2" ON ( "t1"."ab" = "t2"."cd" )
+                  INNER JOIN      "Table3"       ON ( ( "t2"."ef" > "Table3"."gh" 
+                                            AND "t2"."ij" < "Table3"."kl" ) )
+                LEFT OUTER JOIN "Table4"       ON ( "t1"."mn" = "Table4"."op" )',
   [],
 );
 
@@ -584,7 +588,7 @@ is_same_sql_bind(
 $join = $sqla->join(qw[Foo >=<{a=b} Bar]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Foo FULL OUTER JOIN Bar ON Foo.a=Bar.b', [],
+  '"Foo" FULL OUTER JOIN "Bar" ON ( "Foo"."a" = "Bar"."b" )', [],
   'full outer join',
 );
 
@@ -594,7 +598,7 @@ is_same_sql_bind(
 $join = $sqla->join(qw[Table1|t1  t1.ab=t2.cd Table2|t2]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Table1 AS t1 INNER JOIN  Table2 AS t2 ON t1.ab=t2.cd',
+  '"Table1" AS "t1" INNER JOIN  "Table2" AS "t2" ON ( "t1"."ab"="t2"."cd" )',
   [],
   'explicit tables in join condition'
  );
@@ -613,14 +617,15 @@ is_deeply($merged,
 # test a customized instance
 #----------------------------------------------------------------------
 
-$sqla = SQL::Abstract::More->new(table_alias  => '%1$s %2$s',
-                                 limit_offset => 'LimitXY',
-                                 sql_dialect  => 'MsAccess');
+$sqla = sqla(table_alias  => '%1$s %2$s',
+             limit_offset => 'LimitXY',
+             sql_dialect  => 'MsAccess',
+         );
 
 $join = $sqla->join(qw[Foo|f  =>{fk_A=pk_A,fk_B=pk_B} Bar]);
 is_same_sql_bind(
   $join->{sql}, $join->{bind},
-  'Foo f LEFT OUTER JOIN (Bar) ON f.fk_A = Bar.pk_A AND f.fk_B = Bar.pk_B', [],
+  '"Foo" "f" LEFT OUTER JOIN ("Bar") ON ( ( "f"."fk_A" = "Bar"."pk_A" AND "f"."fk_B" = "Bar"."pk_B" ) )', [],
 );
 
 
@@ -635,14 +640,14 @@ ok($sqla->join_assoc_right,
    'join_assoc_right is true');
 
 
-$sqla = SQL::Abstract::More->new(sql_dialect => 'Oracle');
+$sqla = sqla(sql_dialect => 'Oracle');
 ($sql, @bind) = $sqla->select(
   -columns => [qw/col1|c1 col2|c2/],
   -from    => [-join => qw/Foo|f fk=pk Bar|b/],
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT col1 c1, col2 c2 FROM Foo f INNER JOIN Bar b ON f.fk=b.pk',
+  'SELECT "col1" "c1", "col2" "c2" FROM "Foo" "f" INNER JOIN "Bar" "b" ON ( "f"."fk" = "b"."pk" )',
   []
 );
 
@@ -654,14 +659,14 @@ is_same_sql_bind(
 
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM (SELECT subq_A.*, ROWNUM rownum__index FROM (SELECT * FROM Foo) subq_A WHERE ROWNUM <= ?) subq_B WHERE rownum__index >= ?',
+  'SELECT * FROM (SELECT subq_A.*, ROWNUM rownum__index FROM (SELECT * FROM "Foo") subq_A WHERE ROWNUM <= ?) subq_B WHERE rownum__index >= ?',
   [15, 6],
 );
 
 
 
 # Oracle12c version of limit/offset
-$sqla = SQL::Abstract::More->new(sql_dialect => 'Oracle12c');
+$sqla = sqla( sql_dialect => 'Oracle12c' );
 ($sql, @bind) = $sqla->limit_offset(123, 456);
 is_same_sql_bind(
   $sql, \@bind,
@@ -675,7 +680,7 @@ is_same_sql_bind(
 # method redefinition
 #----------------------------------------------------------------------
 
-$sqla = SQL::Abstract::More->new(
+$sqla = sqla(
     limit_offset => sub {
       my ($self, $limit, $offset) = @_;
       defined $limit or die 'NO LIMIT!';
@@ -696,7 +701,7 @@ is_same_sql_bind(
 # max_members_IN
 #----------------------------------------------------------------------
 
-$sqla = SQL::Abstract::More->new(
+$sqla = sqla(
   max_members_IN => 10
  );
 
@@ -705,10 +710,10 @@ my @vals = (1 .. 35);
 
 is_same_sql_bind(
   $sql, \@bind,
-  ' WHERE ( ( foo IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-       . ' OR foo IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-       . ' OR foo IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-       . ' OR foo IN ( ?, ?, ?, ?, ?) ) )',
+  ' WHERE ( ( "foo" IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+       . ' OR "foo" IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+       . ' OR "foo" IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+       . ' OR "foo" IN ( ?, ?, ?, ?, ?) ) )',
   [1 .. 35]
 );
 
@@ -716,14 +721,14 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->where({foo => {-not_in => \@vals}});
 is_same_sql_bind(
   $sql, \@bind,
-  ' WHERE ( ( foo NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-      . ' AND foo NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-      . ' AND foo NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
-      . ' AND foo NOT IN ( ?, ?, ?, ?, ?) ) )',
+  ' WHERE ( ( "foo" NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+      . ' AND "foo" NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+      . ' AND "foo" NOT IN ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ? ) '
+      . ' AND "foo" NOT IN ( ?, ?, ?, ?, ?) ) )',
   [1 .. 35]
 );
 
-$sqla = SQL::Abstract::More->new(
+$sqla = sqla(
   max_members_IN => 3
  );
 
@@ -731,8 +736,8 @@ $sqla = SQL::Abstract::More->new(
                               bar => {-not_in => [6 .. 10]}});
 is_same_sql_bind(
   $sql, \@bind,
-  ' WHERE (     ( bar NOT IN ( ?, ?, ? ) AND bar NOT IN ( ?, ? ) )'
-        . ' AND ( foo IN ( ?, ?, ? ) OR foo IN ( ?, ? ) )  )',
+  ' WHERE ( ( ( "bar" NOT IN ( ?, ?, ? ) AND "bar" NOT IN ( ?, ? ) )'
+        . ' AND ( "foo" IN ( ?, ?, ? ) OR "foo" IN ( ?, ? ) ) ) )',
   [6 .. 10, 1 .. 5]
 );
 
@@ -740,7 +745,7 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->where({foo => {-in => 123}});
 is_same_sql_bind(
   $sql, \@bind,
-  ' WHERE ( foo IN (?) )',
+  ' WHERE ( "foo" IN (?) )',
   [123],
 );
 
@@ -749,6 +754,7 @@ is_same_sql_bind(
 # -in with objects
 #----------------------------------------------------------------------
 
+$sqla = sqla ();
 my $vals = bless [1, 2], 'Array::PseudoScalar'; # doesn't matter if not loaded
 
 ($sql, @bind) = $sqla->where({foo => {-in     => $vals},
@@ -756,7 +762,7 @@ my $vals = bless [1, 2], 'Array::PseudoScalar'; # doesn't matter if not loaded
 
 is_same_sql_bind(
   $sql, \@bind,
-  ' WHERE ( bar NOT IN ( ?, ? ) AND foo IN ( ?, ? ) )',
+  ' WHERE ( ( "bar" NOT IN ( ?, ? ) AND "foo" IN ( ?, ? ) ) )',
   [1, 2, 1, 2],
 );
 
@@ -765,28 +771,28 @@ is_same_sql_bind(
 # select_implicitly_for
 #----------------------------------------------------------------------
 
-my $sqla_RO = SQL::Abstract::More->new(
+my $sqla_RO = sqla(
   select_implicitly_for => 'READ ONLY',
  );
 
 ($sql, @bind) = $sqla_RO->select(-from => 'Foo');
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM FOO FOR READ ONLY',  [],
+  'SELECT * FROM "FOO" FOR READ ONLY',  [],
   'select_implicitly_for - basic',
 );
 
 ($sql, @bind) = $sqla_RO->select(-from => 'Foo', -for => 'UPDATE');
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM FOO FOR UPDATE',  [],
+  'SELECT * FROM "FOO" FOR UPDATE',  [],
   'select_implicitly_for - override',
 );
 
 ($sql, @bind) = $sqla_RO->select(-from => 'Foo', -for => undef);
 is_same_sql_bind(
   $sql, \@bind,
-  'SELECT * FROM FOO',  [],
+  'SELECT * FROM "FOO"',  [],
   'select_implicitly_for - disable',
 );
 
@@ -803,7 +809,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(bar, foo) VALUES (?, ?)',
+  'INSERT INTO "Foo" ( "bar", "foo" ) VALUES (?, ?)',
   [2, 1],
   'insert - hashref',
 );
@@ -815,7 +821,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo VALUES (?, ?)',
+  'INSERT INTO "Foo" VALUES (?, ?)',
   [1, 2],
   'insert - arrayref',
 );
@@ -829,7 +835,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(a, b) SELECT x, y FROM Bar',
+  'INSERT INTO "Foo"("a", "b") SELECT "x", "y" FROM "Bar"',
   [],
   'insert .. select',
 );
@@ -841,7 +847,7 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->insert('Foo', {foo => 1, bar => 2}); 
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(bar, foo) VALUES (?, ?)',
+  'INSERT INTO "Foo" ( "bar", "foo" ) VALUES (?, ?)',
   [2, 1],
 );
 
@@ -856,7 +862,7 @@ ok($@, 'unknown arg to insert()');
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT IGNORE INTO Foo(bar, foo) VALUES (?, ?)',
+  'INSERT IGNORE INTO "Foo" ( "bar", "foo" ) VALUES (?, ?)',
   [2, 1],
 );
 ($sql, @bind) = $sqla->insert(
@@ -866,7 +872,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT OR IGNORE INTO Foo(bar, foo) VALUES (?, ?)',
+  'INSERT OR IGNORE INTO "Foo" ( "bar", "foo" ) VALUES (?, ?)',
   [2, 1],
 );
 
@@ -880,7 +886,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(bar, foo) VALUES (?, ?) RETURNING key',
+  'INSERT INTO "Foo" ( "bar", "foo" ) VALUES (?, ?) RETURNING "key"',
   [2, 1],
 );
 
@@ -891,7 +897,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(bar, foo) VALUES (?, ?) RETURNING k1, k2',
+  'INSERT INTO "Foo" ( "bar", "foo" ) VALUES (?, ?) RETURNING "k1", "k2"',
   [2, 1],
 );
 
@@ -902,7 +908,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'INSERT INTO Foo(bar, foo) VALUES (?, ?) RETURNING k1, k2 INTO ?, ?',
+  'INSERT INTO "Foo" ( "bar", "foo" ) VALUES (?, ?) RETURNING "k1", "k2" INTO ?, ?',
   [2, 1, \$k2, \$k1],
 );
 
@@ -947,7 +953,7 @@ SKIP: {
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET bar = ?, foo = ? WHERE buz = ?',
+  'UPDATE "Foo" SET "bar" = ?, "foo" = ? WHERE ( "buz" = ? )',
   [2, 1, 3],
 );
 
@@ -958,7 +964,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET bar = ?, foo = ?',
+  'UPDATE "Foo" SET "bar" = ?, "foo" = ?',
   [2, 1],
 );
 
@@ -966,7 +972,7 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->update('Foo', {foo => 1, bar => 2}, {buz => 3});
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET bar = ?, foo = ? WHERE buz = ?',
+  'UPDATE "Foo" SET "bar" = ?, "foo" = ? WHERE ( "buz" = ? )',
   [2, 1, 3],
 );
 
@@ -978,7 +984,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo AS a SET a.bar = ?, a.foo = ? WHERE a.buz = ?',
+  'UPDATE "Foo" AS "a" SET "a"."bar" = ?, "a"."foo" = ? WHERE ( "a"."buz" = ? )',
   [2, 1, 3],
 );
 
@@ -993,7 +999,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET bar = ?, foo = ? WHERE buz = ? ORDER BY baz LIMIT ?',
+  'UPDATE "Foo" SET "bar" = ?, "foo" = ? WHERE ( "buz" = ? ) ORDER BY "baz" LIMIT ?',
   [2, 1, 3, 10],
   'update with -order_by/-limit',
 );
@@ -1004,7 +1010,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo INNER JOIN Bar ON Foo.fk=Bar.pk SET bar = ?, foo = ?',
+  'UPDATE "Foo" INNER JOIN "Bar" ON ( "Foo"."fk" = "Bar"."pk" ) SET "bar" = ?, "foo" = ?',
   [2, 1],
 );
 
@@ -1019,7 +1025,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET foo = ? RETURNING key',
+  'UPDATE "Foo" SET "foo" = ? RETURNING "key"',
   [1],
   'update returning (scalar)',
 );
@@ -1031,7 +1037,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET foo = ? RETURNING k1, k2',
+  'UPDATE "Foo" SET "foo" = ? RETURNING "k1", "k2"',
   [1],
   'update returning (arrayref)',
 );
@@ -1043,7 +1049,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE Foo SET foo = ? RETURNING k1, k2 INTO ?, ?',
+  'UPDATE "Foo" SET "foo" = ? RETURNING "k1", "k2" INTO ?, ?',
   [1, \$kupd1, \$kupd2],
   'update returning (hashref)',
 );
@@ -1059,7 +1065,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'UPDATE IGNORE Foo SET foo = ?',
+  'UPDATE IGNORE "Foo" SET "foo" = ?',
   [1],
   'update IGNORE',
 );
@@ -1078,7 +1084,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'DELETE FROM Foo WHERE buz = ?',
+  'DELETE FROM "Foo" WHERE "buz" = ?',
   [3],
   'delete',
 );
@@ -1087,7 +1093,7 @@ is_same_sql_bind(
 ($sql, @bind) = $sqla->delete('Foo', {buz => 3});
 is_same_sql_bind(
   $sql, \@bind,
-  'DELETE FROM Foo WHERE buz = ?',
+  'DELETE FROM "Foo" WHERE "buz" = ?',
   [3],
   'delete, old API',
 );
@@ -1099,7 +1105,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'DELETE FROM Foo AS a WHERE buz = ?',
+  'DELETE FROM "Foo" AS "a" WHERE "buz" = ?',
   [3],
   'delete with table alias',
 );
@@ -1114,7 +1120,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'DELETE FROM Foo WHERE buz = ? ORDER BY baz LIMIT ?',
+  'DELETE FROM "Foo" WHERE ( "buz" = ? ) ORDER BY "baz" LIMIT ?',
   [3, 10],
   'delete with -order_by/-limit',
 );
@@ -1129,7 +1135,7 @@ is_same_sql_bind(
 );
 is_same_sql_bind(
   $sql, \@bind,
-  'DELETE IGNORE FROM Foo WHERE buz = ?',
+  'DELETE IGNORE FROM "Foo" WHERE ( "buz" = ? )',
   [3],
   'delete with -add_sql',
 );
@@ -1140,8 +1146,6 @@ is_same_sql_bind(
 #----------------------------------------------------------------------
 # quote
 #----------------------------------------------------------------------
-
-$sqla = SQL::Abstract::More->new({ quote_char => q{"}, name_sep => q{.} });
 
 ($sql, @bind) = $sqla->select(
     -from => [
@@ -1163,18 +1167,56 @@ is_same_sql_bind(
   $sql, \@bind,
   'SELECT "left"."id" AS "left_id", max("right"."id") AS "max_right_id" '
     . 'FROM "t1" AS "left" '
-    . 'INNER JOIN "t2" AS "link" ON ("left"."id" = "link"."t1_id")'
-    . 'LEFT OUTER JOIN "t3" AS "right" ON ("link"."t3_id" = "right"."id")',
+    . 'INNER JOIN "t2" AS "link" ON ( "left"."id" = "link"."t1_id" ) '
+    . 'LEFT OUTER JOIN "t3" AS "right" ON ( "link"."t3_id" = "right"."id" )',
 
   [],
 );
 
 #----------------------------------------------------------------------
+# quote table name
+#----------------------------------------------------------------------
+
+($sql, @bind) = $sqla->select(
+        -from    => 'Foo|Bar',
+        -columns => 'a|b'
+);
+
+is_same_sql_bind(
+  $sql, \@bind,
+      'SELECT "a" AS "b" FROM "Foo" AS "Bar"',
+  [],
+);
+
+($sql, @bind) = $sqla->delete(
+        -from    => 'Foo|Bar',
+        -where => { a => 3 },
+);
+
+is_same_sql_bind(
+  $sql, \@bind,
+        'DELETE FROM "Foo" AS "Bar" WHERE ( "a" = ? )',
+  [3],
+);
+
+($sql, @bind) = $sqla->update(
+        -table    => 'Foo|Bar',
+        -set => { b => 2 },
+        -where => { a => 3 },
+);
+
+is_same_sql_bind(
+  $sql, \@bind,
+  'UPDATE "Foo" AS "Bar" SET "b" = ? WHERE ( "a" = ? )',
+  [2, 3],
+);
+
+
+#----------------------------------------------------------------------
 # CTE
 #----------------------------------------------------------------------
 
-$sqla = SQL::Abstract::More->new;
-$sqla = $sqla->with(
+$sqla = sqla()->with(
   -table => 't2',
   -columns => [ 'store', 'avg_order' ],
   -as_select => {
@@ -1191,16 +1233,15 @@ $sqla = $sqla->with(
 
 is_same_sql_bind(
   $sql, \@bind,
-q{WITH t2 (store,avg_order) AS
-  (SELECT store, average_order
-   FROM table1
-   GROUP BY store)
-SELECT t1.id, t2.avg_order AS avg
-FROM Table1 AS t1
-INNER JOIN t2 USING(store)
+q{WITH t2 ("store","avg_order") AS
+  (SELECT "store", "average_order"
+   FROM "table1"
+   GROUP BY "store")
+SELECT "t1"."id", "t2"."avg_order" AS "avg"
+FROM "Table1" AS "t1"
+INNER JOIN "t2" USING("store")
 },
-[],
-'CTE'
+[]
 );
 
 


### PR DESCRIPTION

Tables and columns were not properly quoted in all instances when the
quote_char constructor option is set.  Some were underquoted, some over quooted,
and some table expressions were quoted.  This lead iin the latter cases to illegal SQL.

The intrinsic problem lies with treating them as strings, rather than
as objects, so there is no "quote" or "quotable" state assigned to a
given SQL fragment.  The code has to rely upon heuristics to know when
to quote (e.g. a bare identifier) and when not to quote (interpolation
of an SQL expression).  This requires carrying external state (e.g.,
the new is_literal flag from _parse_table and in the return from
table_alias), and informing the quoting apparati in table_alias() and
column_alias() of whether quoting is permissible via the "quote_name"
and "quote_aliased_name" options.

