### PR TITLE
MANIFEST.SKIP allowed Makefile.PL rather than Build.PL,

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,4 +1,4 @@
-^(?!script/|examples/|lib/|inc/|t/|Makefile.PL$|README$|MANIFEST$|Changes$|META.yml$)
+^(?!script/|examples/|lib/|inc/|t/|Build.PL$|README$|MANIFEST$|Changes$|META.yml$)
 
 
 # Avoid version control files.


### PR DESCRIPTION
resulting in no build script in the distribution